### PR TITLE
implement original tagtime random generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "moment": "^2.22.2",
     "npm": "^6.0.0",
     "photonkit": "^0.1.2",
+    "random-js": "^1.0.8",
     "react": "^16.6.0",
     "react-autosuggest": "^9.4.2",
     "react-dom": "^16.6.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/electron-window-state": "^2.0.33",
     "@types/lodash": "^4.14.117",
     "@types/mocha": "^5.2.5",
+    "@types/random-js": "^1.0.31",
     "@types/react": "^16.4.18",
     "@types/react-autosuggest": "^9.3.6",
     "@types/react-dom": "^16.0.9",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/electron-window-state": "^2.0.33",
     "@types/lodash": "^4.14.117",
     "@types/mocha": "^5.2.5",
-    "@types/random-js": "^1.0.31",
     "@types/react": "^16.4.18",
     "@types/react-autosuggest": "^9.3.6",
     "@types/react-dom": "^16.0.9",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "moment": "^2.22.2",
     "npm": "^6.0.0",
     "photonkit": "^0.1.2",
-    "random-js": "^1.0.8",
     "react": "^16.6.0",
     "react-autosuggest": "^9.4.2",
     "react-dom": "^16.6.0",

--- a/src/main-process/config.ts
+++ b/src/main-process/config.ts
@@ -102,7 +102,7 @@ export class Config {
       name: ConfigName.pingFileStart,
       type: "datetime-local",
       label:
-        "Time from which this ping sequence starts (only needed if using a ping file with pings in it from classic TagTime, or with a different seed or period)",
+      "Time from which this ping sequence starts (only needed if using a ping file with pings in it from classic TagTime, or with a different seed or period, choose 07/10/2007, 07:56 PM for compliance with classic TagTime)",
       configurable: true,
       default: null
     },

--- a/src/main-process/config.ts
+++ b/src/main-process/config.ts
@@ -185,7 +185,7 @@ export class Config {
     const initialConfig = Config.defaultDict();
     // These two default config values are set here rather than in fieldInfo because the "app"
     // object isn't available in the test context
-    initialConfig.seed = require("random-js")().integer(0, Math.pow(2, 32) - 1);
+    initialConfig.seed = 11193462
     initialConfig.pingFilePath = path.join(this.configPath, pingFileName);
 
     const options: { defaults: {}; cwd?: string } = { defaults: initialConfig };

--- a/src/main-process/config.ts
+++ b/src/main-process/config.ts
@@ -117,7 +117,7 @@ export class Config {
       name: ConfigName.seed,
       type: "number",
       label:
-        "Seed for your sequence of pings (random whole number)",
+        "Seed for your sequence of pings (random whole number) choose 11193462 for classic TagTime compliance",
       configurable: true,
       default: null // set at runtime
     },

--- a/src/main-process/config.ts
+++ b/src/main-process/config.ts
@@ -117,7 +117,7 @@ export class Config {
       name: ConfigName.seed,
       type: "number",
       label:
-        "Seed for your sequence of pings (random whole number; not backwards compatible with classic TagTime)",
+        "Seed for your sequence of pings (random whole number)",
       configurable: true,
       default: null // set at runtime
     },

--- a/src/main-process/config.ts
+++ b/src/main-process/config.ts
@@ -185,7 +185,7 @@ export class Config {
     const initialConfig = Config.defaultDict();
     // These two default config values are set here rather than in fieldInfo because the "app"
     // object isn't available in the test context
-    initialConfig.seed = 11193462
+    initialConfig.seed = require("random-js")().integer(0, Math.pow(2, 32) - 1);
     initialConfig.pingFilePath = path.join(this.configPath, pingFileName);
 
     const options: { defaults: {}; cwd?: string } = { defaults: initialConfig };

--- a/src/pingtimes.ts
+++ b/src/pingtimes.ts
@@ -5,23 +5,9 @@
  */
 
 import * as moment from "moment";
+import { RandomGenerator } from "./randomgenerator"
 
 type UnixTime = number;
-export class RandomGenerator {
-  private IA: number = 16807;
-  private IM: number = 2147483647;
-  seed: number = 0;
-  constructor() {
-  }
-  public setSeed(seed : number){
-    this.seed = seed;
-  }
-  public ran0() {
-    this.seed = this.IA * this.seed % this.IM;
-    return this.seed/this.IM
-  }
-}
-
 export class PingTimes {
   /**
    * The birth of tagtime.

--- a/src/pingtimes.ts
+++ b/src/pingtimes.ts
@@ -5,15 +5,29 @@
  */
 
 import * as moment from "moment";
-import * as Random from "random-js";
 
 type UnixTime = number;
+export class RandomGenerator {
+  private IA: number = 16807;
+  private IM: number = 2147483647;
+  seed: number = 0;
+  constructor() {
+  }
+  public setSeed(seed : number){
+    this.seed = seed;
+  }
+  public ran0() {
+    this.seed = this.IA * this.seed % this.IM;
+    return this.seed/this.IM
+  }
+}
+
 export class PingTimes {
   /**
    * The birth of tagtime.
    * The earliest possible ping in any sequence is on the epoch.
    */
-  public static epoch: UnixTime = 1184083200 * 1000;
+  public static epoch: UnixTime = 1184097393 * 1000;
 
   public period: number;
   public seed: number;
@@ -29,7 +43,7 @@ export class PingTimes {
    */
   private pings: UnixTime[] = [];
 
-  private engine: Random.Engine | undefined;
+  private engine: RandomGenerator = new RandomGenerator();
 
   /**
    * @param {integer} period The mean period in milliseconds
@@ -40,7 +54,7 @@ export class PingTimes {
     this.period = period;
     this.seed = seed;
     if (startOfPings) {
-      this.startOfPings = moment(startOfPings).valueOf(); // convert to js Time Value
+      this.startOfPings = moment(startOfPings).valueOf();
     } else {
       this.startOfPings = PingTimes.epoch;
     }
@@ -89,14 +103,7 @@ export class PingTimes {
    * Re-initialise rand with the root seed
    */
   private reseed() {
-    /* NOTE: because we're using a different PRNG to original tagtime,
-     * sequences generated from the same seed won't match up.
-     * To manage this, we never try and validate pings prior to startOfPings.
-     * Subsequent pings will continue to follow the same distribution.
-     *
-     * Seed with a 32bit integer
-     */
-    this.engine = Random.engines.mt19937().seed(this.seed);
+    this.engine.setSeed(this.seed);
   }
 
   /**
@@ -107,7 +114,7 @@ export class PingTimes {
     if (!this.engine) {
       this.reseed();
     }
-    return Random.real(0, 1)(this.engine!);
+    return this.engine.ran0();
   }
 
   /**

--- a/src/pingtimes.ts
+++ b/src/pingtimes.ts
@@ -12,6 +12,7 @@ export class PingTimes {
   /**
    * The birth of tagtime.
    * The earliest possible ping in any sequence is on the epoch.
+   * We use the newest value from the original TagTime implementation (changed in 9/2018)
    */
   public static epoch: UnixTime = 1184097393 * 1000;
 

--- a/src/randomgenerator.ts
+++ b/src/randomgenerator.ts
@@ -1,4 +1,5 @@
 // Implements a pseudo random number generator to match the original Tagtime Ping schedule
+// This is ran0 from Numerical Recipes and has a period of ~2 billion.
 // This isn't a perfect algorithm, see https://github.com/tagtime/TagTime/issues/62
 export class RandomGenerator {
   private IA: number = 16807;

--- a/src/randomgenerator.ts
+++ b/src/randomgenerator.ts
@@ -1,0 +1,12 @@
+export class RandomGenerator {
+  private IA: number = 16807;
+  private IM: number = 2147483647;
+  private seed: number = 0;
+  public setSeed(seed : number){
+    this.seed = seed;
+  }
+  public ran0() {
+    this.seed = this.IA * this.seed % this.IM;
+    return this.seed/this.IM
+  }
+}

--- a/src/randomgenerator.ts
+++ b/src/randomgenerator.ts
@@ -1,3 +1,5 @@
+// Implements a pseudo random number generator to match the original Tagtime Ping schedule
+// This isn't a perfect algorithm, see https://github.com/tagtime/TagTime/issues/62
 export class RandomGenerator {
   private IA: number = 16807;
   private IM: number = 2147483647;

--- a/test/pingtimes.ts
+++ b/test/pingtimes.ts
@@ -126,36 +126,33 @@ describe("Pingtimes", function() {
       modeMatcher(gapsMode);
     }
   });
-});
 
-describe("PingtimesReproducesOriginalImplementation", function() {
-  let pings: PingTimes;
-  beforeEach(function() {
-    // we use the seed from the TagTime implementation
-    pings = new PingTimes(45 * 60 * 1000, 11193462 , PingTimes.epoch);
-  });
-
-  describe("next()", function() {
-    it("first ping should be reproduced", function() {
-      const time = PingTimes.epoch+1;
-      pings.next(time).should.be.equal(1184098754*1000);
+  describe("backwards compatibility with original TagTime", function() {
+    context("with the default seed", function() {
+      beforeEach(function(){
+        pings = new PingTimes(45 * 60 * 1000, 11193462 , PingTimes.epoch);
+      });
+      it("first ping should be reproduced", function() {
+        const time = PingTimes.epoch+1;
+        pings.next(time).should.be.equal(1184098754*1000);
+      });
+      it("ping in 2018 should be reproduced",function(){
+        const time = 1543080000*1000;
+        pings.next(time).should.be.equal(1543081241*1000);
+      });
     });
-
-    it("first ping should reproduced with different seed", function() {
-      const time = PingTimes.epoch+1;
-      pings.seed = 123456;
-      pings.next(time).should.be.equal(1184097486*1000);
-    });
-
-    it("ping should match original implementation in 2018",function(){
-      const time = 1543080000*1000;
-      pings.next(time).should.be.equal(1543081241*1000);
-    });
-
-    it("ping should match original implementation in 2018 with different seed",function(){
-      const time = 1543080000*1000;
-      pings.seed = 123456;
-      pings.next(time).should.be.equal(1543080933*1000);
+    context("with different seed",function(){
+      beforeEach(function(){
+        pings = new PingTimes(45 * 60 * 1000, 123456, PingTimes.epoch);
+      });
+      it("first ping should be reproduced", function() {
+        const time = PingTimes.epoch+1;
+        pings.next(time).should.be.equal(1184097486*1000);
+      });
+      it("ping in 2018 should be reproduced",function(){
+        const time = 1543080000*1000;
+        pings.next(time).should.be.equal(1543080933*1000);
+      });
     });
   });
 });

--- a/test/pingtimes.ts
+++ b/test/pingtimes.ts
@@ -136,14 +136,26 @@ describe("PingtimesReproducesOriginalImplementation", function() {
   });
 
   describe("next()", function() {
-    it("first ping should reproduce original implementation", function() {
+    it("first ping should be reproduced", function() {
       const time = PingTimes.epoch+1;
       pings.next(time).should.be.equal(1184098754*1000);
+    });
+
+    it("first ping should reproduced with different seed", function() {
+      const time = PingTimes.epoch+1;
+      pings.seed = 123456;
+      pings.next(time).should.be.equal(1184097486*1000);
     });
 
     it("ping should match original implementation in 2018",function(){
       const time = 1543080000*1000;
       pings.next(time).should.be.equal(1543081241*1000);
-    })
+    });
+
+    it("ping should match original implementation in 2018 with different seed",function(){
+      const time = 1543080000*1000;
+      pings.seed = 123456;
+      pings.next(time).should.be.equal(1543080933*1000);
+    });
   });
 });

--- a/test/pingtimes.ts
+++ b/test/pingtimes.ts
@@ -89,7 +89,7 @@ describe("Pingtimes", function() {
     this.timeout(10000); // When coverage instrumented, this is slooow
 
     // Fix the seed so we don't get spurious failures
-    pings.seed = 0;
+    pings.seed = 1;
     // a smaller period should lead to more collisions, so a better mode
     pings.period = 3 * 1000 * 60;
     pings.reset();

--- a/test/pingtimes.ts
+++ b/test/pingtimes.ts
@@ -5,7 +5,7 @@ import stats = require("stats-lite");
 import { PingTimes } from "../src/pingtimes";
 
 describe("Pingtimes", function() {
-  const time = PingTimes.epoch + 30000000; // close to the epoch speeds things up
+  const time = PingTimes.epoch + 50000000; // close to the epoch speeds things up
   const notBefore = time - 10000000;
   let pings: PingTimes;
 

--- a/test/pingtimes.ts
+++ b/test/pingtimes.ts
@@ -133,12 +133,12 @@ describe("Pingtimes", function() {
         pings = new PingTimes(45 * 60 * 1000, 11193462 , PingTimes.epoch);
       });
       it("first ping should be reproduced", function() {
-        const time = PingTimes.epoch+1;
-        pings.next(time).should.be.equal(1184098754*1000);
+        const t = PingTimes.epoch+1;
+        pings.next(t).should.be.equal(1184098754*1000);
       });
       it("ping in 2018 should be reproduced",function(){
-        const time = 1543080000*1000;
-        pings.next(time).should.be.equal(1543081241*1000);
+        const t = 1543080000*1000;
+        pings.next(t).should.be.equal(1543081241*1000);
       });
     });
     context("with different seed",function(){
@@ -146,12 +146,12 @@ describe("Pingtimes", function() {
         pings = new PingTimes(45 * 60 * 1000, 123456, PingTimes.epoch);
       });
       it("first ping should be reproduced", function() {
-        const time = PingTimes.epoch+1;
-        pings.next(time).should.be.equal(1184097486*1000);
+        const t = PingTimes.epoch+1;
+        pings.next(t).should.be.equal(1184097486*1000);
       });
       it("ping in 2018 should be reproduced",function(){
-        const time = 1543080000*1000;
-        pings.next(time).should.be.equal(1543080933*1000);
+        const t = 1543080000*1000;
+        pings.next(t).should.be.equal(1543080933*1000);
       });
     });
   });

--- a/test/pingtimes.ts
+++ b/test/pingtimes.ts
@@ -127,3 +127,23 @@ describe("Pingtimes", function() {
     }
   });
 });
+
+describe("PingtimesReproducesOriginalImplementation", function() {
+  let pings: PingTimes;
+  beforeEach(function() {
+    // we use the seed from the TagTime implementation
+    pings = new PingTimes(45 * 60 * 1000, 11193462 , PingTimes.epoch);
+  });
+
+  describe("next()", function() {
+    it("first ping should reproduce original implementation", function() {
+      const time = PingTimes.epoch+1;
+      pings.next(time).should.be.equal(1184098754*1000);
+    });
+
+    it("ping should match original implementation in 2018",function(){
+      const time = 1543080000*1000;
+      pings.next(time).should.be.equal(1543081241*1000);
+    })
+  });
+});


### PR DESCRIPTION
This PR replaces the random generator with the original one from Tagtime.
When using the right start time and the right Seed (c.f. [here](https://forum.beeminder.com/t/official-reference-implementation-of-the-tagtime-universal-ping-schedule/4282)) one gets the exact same pings as in the original implementation.

Open for recommendations to improve the code as I'm not very proficient with Type/Javascript. 